### PR TITLE
Invalid UTF-8 character fix

### DIFF
--- a/completions/bash/code-minimap.bash
+++ b/completions/bash/code-minimap.bash
@@ -26,7 +26,7 @@ _code-minimap() {
 
     case "${cmd}" in
         code-minimap)
-            opts=" -h -H -V  --help --version --horizontal-scale --vertical-scale --padding  <FILE>  completion help"
+            opts=" -h -H -V  --help --version --horizontal-scale --vertical-scale --padding --encoding  <FILE>  completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -51,6 +51,10 @@ _code-minimap() {
                     ;;
                 --padding)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --encoding)
+                    COMPREPLY=($(compgen -W "UTF8 UTF8Lossy" -- "${cur}"))
                     return 0
                     ;;
                 *)

--- a/completions/elvish/code-minimap.elv
+++ b/completions/elvish/code-minimap.elv
@@ -20,6 +20,7 @@ edit:completion:arg-completer[code-minimap] = [@words]{
             cand -V 'Specify vertical scale factor'
             cand --vertical-scale 'Specify vertical scale factor'
             cand --padding 'Specify padding width'
+            cand --encoding 'Specify input encoding'
             cand -h 'Prints help information'
             cand --help 'Prints help information'
             cand --version 'Prints version information'

--- a/completions/fish/code-minimap.fish
+++ b/completions/fish/code-minimap.fish
@@ -1,6 +1,7 @@
 complete -c code-minimap -n "__fish_use_subcommand" -s H -l horizontal-scale -d 'Specify horizontal scale factor'
 complete -c code-minimap -n "__fish_use_subcommand" -s V -l vertical-scale -d 'Specify vertical scale factor'
 complete -c code-minimap -n "__fish_use_subcommand" -l padding -d 'Specify padding width'
+complete -c code-minimap -n "__fish_use_subcommand" -l encoding -d 'Specify input encoding' -r -f -a "UTF8 UTF8Lossy"
 complete -c code-minimap -n "__fish_use_subcommand" -s h -l help -d 'Prints help information'
 complete -c code-minimap -n "__fish_use_subcommand" -l version -d 'Prints version information'
 complete -c code-minimap -n "__fish_use_subcommand" -f -a "completion" -d 'Generate shell completion file'

--- a/completions/powershell/_code-minimap.ps1
+++ b/completions/powershell/_code-minimap.ps1
@@ -25,6 +25,7 @@ Register-ArgumentCompleter -Native -CommandName 'code-minimap' -ScriptBlock {
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Specify vertical scale factor')
             [CompletionResult]::new('--vertical-scale', 'vertical-scale', [CompletionResultType]::ParameterName, 'Specify vertical scale factor')
             [CompletionResult]::new('--padding', 'padding', [CompletionResultType]::ParameterName, 'Specify padding width')
+            [CompletionResult]::new('--encoding', 'encoding', [CompletionResultType]::ParameterName, 'Specify input encoding')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')

--- a/completions/zsh/_code-minimap
+++ b/completions/zsh/_code-minimap
@@ -20,6 +20,7 @@ _code-minimap() {
 '-V+[Specify vertical scale factor]' \
 '--vertical-scale=[Specify vertical scale factor]' \
 '--padding=[Specify padding width]' \
+'--encoding=[Specify input encoding]: :(UTF8 UTF8Lossy)' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '--version[Prints version information]' \

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+edition = "2018"
+struct_field_align_threshold = 40
+max_width = 120
+comment_width = 120
+reorder_imports = true
+fn_single_line = false

--- a/src/bin/code-minimap/cli.rs
+++ b/src/bin/code-minimap/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use structopt::clap::{self, AppSettings};
+use structopt::clap::{self, arg_enum, AppSettings};
 pub use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -25,6 +25,10 @@ pub struct Opt {
     #[structopt(long = "padding")]
     pub padding: Option<usize>,
 
+    /// Specify input encoding
+    #[structopt(long = "encoding", default_value = "UTF8Lossy", possible_values = &Encoding::variants(), case_insensitive = true)]
+    pub encoding: Encoding,
+
     /// Subcommand
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
@@ -41,4 +45,11 @@ pub struct CompletionOpt {
     /// Target shell name
     #[structopt(possible_values = &clap::Shell::variants())]
     pub shell: clap::Shell,
+}
+
+arg_enum! {
+    pub enum Encoding {
+        UTF8,
+        UTF8Lossy,
+    }
 }

--- a/src/bin/code-minimap/main.rs
+++ b/src/bin/code-minimap/main.rs
@@ -8,12 +8,9 @@ use cli::{CompletionOpt, Opt, StructOpt, Subcommand};
 use code_minimap::LossyReader;
 
 fn main() {
-    if let Err(e) = try_main()
-    {
-        if let Some(ioerr) = e.root_cause().downcast_ref::<io::Error>()
-        {
-            if ioerr.kind() == io::ErrorKind::BrokenPipe
-            {
+    if let Err(e) = try_main() {
+        if let Some(ioerr) = e.root_cause().downcast_ref::<io::Error>() {
+            if ioerr.kind() == io::ErrorKind::BrokenPipe {
                 std::process::exit(0);
             }
         }
@@ -24,28 +21,18 @@ fn main() {
 
 fn try_main() -> anyhow::Result<()> {
     let opt: Opt = Opt::from_args();
-    match &opt.subcommand
-    {
-        Some(Subcommand::Completion(CompletionOpt {
-            shell,
-        })) =>
-        {
-            Opt::clap().gen_completions_to(
-                env!("CARGO_PKG_NAME"),
-                *shell,
-                &mut std::io::stdout(),
-            );
-        },
-        None =>
-        {
+    match &opt.subcommand {
+        Some(Subcommand::Completion(CompletionOpt { shell })) => {
+            Opt::clap().gen_completions_to(env!("CARGO_PKG_NAME"), *shell, &mut std::io::stdout());
+        }
+        None => {
             let stdin = io::stdin();
-            let reader: Box<dyn BufRead> = match &opt.file
-            {
+            let reader: Box<dyn BufRead> = match &opt.file {
                 Some(path) => Box::new(LossyReader::open(path)?),
                 None => Box::new(stdin.lock()),
             };
             code_minimap::print(reader, opt.hscale, opt.vscale, opt.padding)?;
-        },
+        }
     }
     Ok(())
 }

--- a/src/bin/code-minimap/main.rs
+++ b/src/bin/code-minimap/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 use std::{
+    fs::File,
     io::{self, BufRead},
     process,
 };
@@ -28,8 +29,8 @@ fn try_main() -> anyhow::Result<()> {
         None => {
             let stdin = io::stdin();
             let reader: Box<dyn BufRead> = match &opt.file {
-                Some(path) => Box::new(LossyReader::open(path)?),
-                None => Box::new(stdin.lock()),
+                Some(path) => Box::new(LossyReader::new(File::open(path)?)),
+                None => Box::new(LossyReader::new(stdin)),
             };
             code_minimap::print(reader, opt.hscale, opt.vscale, opt.padding)?;
         }

--- a/src/bin/code-minimap/main.rs
+++ b/src/bin/code-minimap/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use cli::{CompletionOpt, Opt, StructOpt, Subcommand};
-use code_minimap::LossyReader;
+use code_minimap::lossy_reader::LossyReader;
 
 fn main() {
     if let Err(e) = try_main() {

--- a/src/bin/code-minimap/main.rs
+++ b/src/bin/code-minimap/main.rs
@@ -1,13 +1,19 @@
 mod cli;
+use std::{
+    io::{self, BufRead},
+    process,
+};
+
 use cli::{CompletionOpt, Opt, StructOpt, Subcommand};
-use std::fs::File;
-use std::io::{self, BufRead, BufReader};
-use std::process;
+use code_minimap::LossyReader;
 
 fn main() {
-    if let Err(e) = try_main() {
-        if let Some(ioerr) = e.root_cause().downcast_ref::<io::Error>() {
-            if ioerr.kind() == io::ErrorKind::BrokenPipe {
+    if let Err(e) = try_main()
+    {
+        if let Some(ioerr) = e.root_cause().downcast_ref::<io::Error>()
+        {
+            if ioerr.kind() == io::ErrorKind::BrokenPipe
+            {
                 std::process::exit(0);
             }
         }
@@ -18,18 +24,28 @@ fn main() {
 
 fn try_main() -> anyhow::Result<()> {
     let opt: Opt = Opt::from_args();
-    match &opt.subcommand {
-        Some(Subcommand::Completion(CompletionOpt { shell })) => {
-            Opt::clap().gen_completions_to(env!("CARGO_PKG_NAME"), *shell, &mut std::io::stdout());
-        }
-        None => {
+    match &opt.subcommand
+    {
+        Some(Subcommand::Completion(CompletionOpt {
+            shell,
+        })) =>
+        {
+            Opt::clap().gen_completions_to(
+                env!("CARGO_PKG_NAME"),
+                *shell,
+                &mut std::io::stdout(),
+            );
+        },
+        None =>
+        {
             let stdin = io::stdin();
-            let reader: Box<dyn BufRead> = match &opt.file {
-                Some(path) => Box::new(BufReader::new(File::open(path)?)),
+            let reader: Box<dyn BufRead> = match &opt.file
+            {
+                Some(path) => Box::new(LossyReader::open(path)?),
                 None => Box::new(stdin.lock()),
             };
             code_minimap::print(reader, opt.hscale, opt.vscale, opt.padding)?;
-        }
+        },
     }
     Ok(())
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,50 +1,9 @@
 use std::{
-    fs::File,
-    io::{self, BufRead, BufReader, Read, Write},
+    io::{self, BufRead, Write},
     ops::Range,
-    path::Path,
 };
 
 use itertools::Itertools;
-
-pub struct LossyReader {
-    reader: BufReader<File>,
-}
-
-impl LossyReader {
-    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
-
-        Ok(Self { reader })
-    }
-}
-
-impl Read for LossyReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.reader.read(buf)
-    }
-}
-
-impl BufRead for LossyReader {
-    fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        self.reader.fill_buf()
-    }
-
-    fn consume(&mut self, amt: usize) {
-        self.reader.consume(amt)
-    }
-
-    fn read_line(&mut self, buf: &mut String) -> std::io::Result<usize> {
-        let mut append_buf = Vec::new();
-        let res = self.read_until(0x0a, &mut append_buf);
-        if let Err(err) = res {
-            return Err(err);
-        }
-        buf.push_str(&String::from_utf8_lossy(&append_buf));
-        Ok(buf.len())
-    }
-}
 
 /// Write minimap to the writer.
 pub fn write(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub(crate) mod core;
+pub mod lossy_reader;
 pub use crate::core::*;

--- a/src/lossy_reader.rs
+++ b/src/lossy_reader.rs
@@ -1,0 +1,44 @@
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader, Read},
+    path::Path,
+};
+
+pub struct LossyReader {
+    reader: BufReader<File>,
+}
+
+impl LossyReader {
+    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+
+        Ok(Self { reader })
+    }
+}
+
+impl Read for LossyReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.reader.read(buf)
+    }
+}
+
+impl BufRead for LossyReader {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.reader.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.reader.consume(amt)
+    }
+
+    fn read_line(&mut self, buf: &mut String) -> std::io::Result<usize> {
+        let mut append_buf = Vec::new();
+        let res = self.read_until(0x0a, &mut append_buf);
+        if let Err(err) = res {
+            return Err(err);
+        }
+        buf.push_str(&String::from_utf8_lossy(&append_buf));
+        Ok(buf.len())
+    }
+}


### PR DESCRIPTION
This fixes an issue with non-utf-8 character streams returning an error. This happens often, if you have text containing characters from the extended ascii range. This pr fixes that by implementing a new BufRead that reads strings using from_utf8_lossy.
This shouldn't affect performance, although a much faster solution could be achieved by manually ignoring all actual byte values and only looking at the utf-8 codes.

A code formatting might need to be applied, as there was no rustfmt config inside the repo.