### PR TITLE
docs: update homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ yay -S code-minimap
 You can install `code-minimap` with Homebrew:
 
 ```
-brew tap wfxr/code-minimap
 brew install code-minimap
 ```
 


### PR DESCRIPTION
I recently added `code-minimap` <sup>1</sup> to https://github.com/Homebrew/homebrew-core, so this step is no longer necessary.

In addition, `code-minimap` can now also be installed through Linuxbrew <sup>2</sup>. Technically the formula from the tap could also be installed through Linuxbrew, but the actual binary that is installed only worked on macOS<sup>3</sup>.

1: https://github.com/Homebrew/homebrew-core/pull/78434
2: https://github.com/Homebrew/linuxbrew-core/blob/fd5f3b1dc5be58e3b7b3a2d5033c7db4ecba7c5a/Formula/code-minimap.rb
3: https://github.com/wfxr/homebrew-code-minimap/blob/5a38e05925fee2c8aaa108aee624d1970c44f669/Formula/code-minimap.rb#L7