### PR TITLE
Add MacPorts installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ You can install `code-minimap` with Homebrew:
 brew install code-minimap
 ```
 
+or with MacPorts:
+
+```
+sudo port install code-minimap
+```
+
 #### From binaries
 
 Prebuilt versions of `code-minimap` for various architectures are available at [Github release page](https://github.com/wfxr/code-minimap/releases).


### PR DESCRIPTION
Since https://github.com/macports/macports-ports/pull/11982 has been merged it is now possible to install `code-minimap` with MacPorts.