### PR TITLE
Add a 'longest line' calculator for minimap.vim background work

### DIFF
--- a/src/bin/code-minimap/cli.rs
+++ b/src/bin/code-minimap/cli.rs
@@ -27,6 +27,10 @@ pub struct App {
     #[clap(long, default_value = Encoding::VARIANTS[0], possible_values = Encoding::VARIANTS, ignore_case = true)]
     pub encoding: Encoding,
 
+    /// Specify mode
+    #[clap(short = 'O', long = "operation", default_value = "GenerateMinimap")]
+    pub operation: Operation,
+
     /// Subcommand
     #[clap(subcommand)]
     pub subcommand: Option<Subcommand>,
@@ -55,3 +59,11 @@ pub enum Encoding {
     UTF8Lossy,
     UTF8,
 }
+
+#[derive(Display, EnumString, EnumVariantNames, PartialEq, Eq)]
+#[strum(ascii_case_insensitive)]
+pub enum Operation {
+    GenerateMinimap,
+    LongestLine
+}
+

--- a/src/core.rs
+++ b/src/core.rs
@@ -82,6 +82,15 @@ pub fn write_to_string(reader: impl BufRead, hscale: f64, vscale: f64, padding: 
     Ok(String::from_utf8(buf).unwrap())
 }
 
+/// Get the longest line of the input
+pub fn get_longest_line(reader: impl BufRead) -> usize {
+    let mut longest = 0;
+    for line in reader.lines() {
+        longest = std::cmp::max(longest, line.unwrap().len());
+    }
+    longest
+}
+
 fn write_frame(mut writer: impl Write, frame: &[Range<usize>], padding: Option<usize>) -> std::io::Result<()> {
     let idx = |pos| {
         frame


### PR DESCRIPTION
As part of https://github.com/wfxr/minimap.vim/issues/160, it is required to have an external program that will scan a file for the longest line. code-minimap is already a dependency for minimap.vim, so tucking the background work into this binary seems a reasonable way to do that.